### PR TITLE
Add support to query for applications using B_CONTAINS

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017. All rights reserved.
+ * Copyright 2010-2018. All rights reserved.
  * Distributed under the terms of the MIT license.
  *
  * Author:

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -322,14 +322,10 @@ MainWindow::BuildList()
 						query.PushAttr("name");
 						query.PushString(predicate, true);
 
-						if (settings.GetUseContains()) 
-						{
-							query.PushOp(B_CONTAINS);		
-						}
+						if (settings.GetSearchStart()) 
+							query.PushOp(B_BEGINS_WITH);		
 						else 
-						{
-							query.PushOp(B_BEGINS_WITH);					
-						}
+							query.PushOp(B_CONTAINS);					
 						
 						query.PushOp(B_AND);
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -321,7 +321,16 @@ MainWindow::BuildList()
 
 						query.PushAttr("name");
 						query.PushString(predicate, true);
-						query.PushOp(B_BEGINS_WITH);
+
+						if (settings.GetUseContains()) 
+						{
+							query.PushOp(B_CONTAINS);		
+						}
+						else 
+						{
+							query.PushOp(B_BEGINS_WITH);					
+						}
+						
 						query.PushOp(B_AND);
 
 						status = query.Fetch();

--- a/QLSettings.cpp
+++ b/QLSettings.cpp
@@ -40,12 +40,12 @@ QLSettings::QLSettings()
 	fDelay = 0;
 	fSaveSearch = false;
 	fSearchTerm = "";
+	fSearchStart = true;
 	fSingleClick = false;
 	fOnTop = false;
 	fShowIgnore = false;
 	fFavoriteList = new BList();
 	fIgnoreList = new IgnoreListView();
-	fUseContains = false;
 
 	path.Append("QuickLaunch_settings");
 	BFile file(path.Path(), B_READ_ONLY);
@@ -98,9 +98,9 @@ QLSettings::QLSettings()
 		if (settings.FindInt32("show ignore", &ignore) == B_OK)
 			fShowIgnore = ignore;
 			
-		int32 usecontains;
-		if (settings.FindInt32("usecontains", &usecontains) == B_OK)
-			fUseContains = usecontains;	
+		int32 searchstart;
+		if (settings.FindInt32("searchstart", &searchstart) == B_OK)
+			fSearchStart = searchstart;	
 	}
 }
 
@@ -132,7 +132,7 @@ QLSettings::SaveSettings()
 	settings.AddInt32("singleclick", fSingleClick);
 	settings.AddInt32("ontop", fOnTop);
 	settings.AddInt32("show ignore", fShowIgnore);
-	settings.AddInt32("usecontains", fUseContains);
+	settings.AddInt32("searchstart", fSearchStart);
 
 	for (int32 i = 0; i < fIgnoreList->CountItems(); i++)
 	{

--- a/QLSettings.cpp
+++ b/QLSettings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017. All rights reserved.
+ * Copyright 2010-2018. All rights reserved.
  * Distributed under the terms of the MIT license.
  *
  * Author:
@@ -37,10 +37,10 @@ QLSettings::QLSettings()
 	fDeskbar = false;
 	fShowVersion = false;
 	fShowPath = true;
+	fSearchStart = true;
 	fDelay = 0;
 	fSaveSearch = false;
 	fSearchTerm = "";
-	fSearchStart = true;
 	fSingleClick = false;
 	fOnTop = false;
 	fShowIgnore = false;
@@ -74,6 +74,10 @@ QLSettings::QLSettings()
 		if (settings.FindInt32("show path", &path) == B_OK)
 			fShowPath = path;
 
+		int32 searchstart;
+		if (settings.FindInt32("searchstart", &searchstart) == B_OK)
+			fSearchStart = searchstart;	
+
 		int32 delay;
 		if (settings.FindInt32("delay", &delay) == B_OK)
 			fDelay = delay;
@@ -97,10 +101,6 @@ QLSettings::QLSettings()
 		int32 ignore;
 		if (settings.FindInt32("show ignore", &ignore) == B_OK)
 			fShowIgnore = ignore;
-			
-		int32 searchstart;
-		if (settings.FindInt32("searchstart", &searchstart) == B_OK)
-			fSearchStart = searchstart;	
 	}
 }
 
@@ -126,13 +126,13 @@ QLSettings::SaveSettings()
 	settings.AddInt32("deskbar", fDeskbar);
 	settings.AddInt32("show version", fShowVersion);
 	settings.AddInt32("show path", fShowPath);
+	settings.AddInt32("searchstart", fSearchStart);
 	settings.AddInt32("delay", fDelay);
 	settings.AddInt32("savesearch", fSaveSearch);
 	settings.AddString("searchterm", fSearchTerm);
 	settings.AddInt32("singleclick", fSingleClick);
 	settings.AddInt32("ontop", fOnTop);
 	settings.AddInt32("show ignore", fShowIgnore);
-	settings.AddInt32("searchstart", fSearchStart);
 
 	for (int32 i = 0; i < fIgnoreList->CountItems(); i++)
 	{

--- a/QLSettings.cpp
+++ b/QLSettings.cpp
@@ -45,6 +45,7 @@ QLSettings::QLSettings()
 	fShowIgnore = false;
 	fFavoriteList = new BList();
 	fIgnoreList = new IgnoreListView();
+	fUseContains = false;
 
 	path.Append("QuickLaunch_settings");
 	BFile file(path.Path(), B_READ_ONLY);
@@ -96,6 +97,10 @@ QLSettings::QLSettings()
 		int32 ignore;
 		if (settings.FindInt32("show ignore", &ignore) == B_OK)
 			fShowIgnore = ignore;
+			
+		int32 usecontains;
+		if (settings.FindInt32("usecontains", &usecontains) == B_OK)
+			fUseContains = usecontains;	
 	}
 }
 
@@ -127,6 +132,7 @@ QLSettings::SaveSettings()
 	settings.AddInt32("singleclick", fSingleClick);
 	settings.AddInt32("ontop", fOnTop);
 	settings.AddInt32("show ignore", fShowIgnore);
+	settings.AddInt32("usecontains", fUseContains);
 
 	for (int32 i = 0; i < fIgnoreList->CountItems(); i++)
 	{

--- a/QLSettings.h
+++ b/QLSettings.h
@@ -38,7 +38,7 @@ public:
 	void	SetOnTop(int32 ontop) { fOnTop = ontop; };
 	void	SetSingleClick(bool singleclick) { fSingleClick = singleclick; };
 	void	SetShowIgnore(int32 ignore) { fShowIgnore = ignore; };
-	void	SetUseContains(int32 usecontains) { fUseContains = usecontains; };
+	void	SetSearchStart(int32 searchstart) { fSearchStart = searchstart; };
 
 	BRect	GetMainWindowFrame() { return fMainWindowFrame; };
 	BRect	GetSetupWindowFrame() { return fSetupWindowFrame; };
@@ -51,7 +51,7 @@ public:
 	int32	GetSingleClick() { return fSingleClick; };
 	int32	GetOnTop() { return fOnTop; };
 	int32	GetShowIgnore() { return fShowIgnore; };
-	int32	GetUseContains() { return fUseContains; };
+	int32	GetSearchStart() { return fSearchStart; };
 
 	void			InitLists();
 	IgnoreListView* IgnoreList() { return fIgnoreList; };
@@ -71,7 +71,7 @@ private:
 	int32	fSingleClick;
 	int32	fOnTop;
 	int32	fShowIgnore;
-	int32	fUseContains;
+	int32	fSearchStart;
 
 	BLocker	fLock;
 };

--- a/QLSettings.h
+++ b/QLSettings.h
@@ -38,6 +38,7 @@ public:
 	void	SetOnTop(int32 ontop) { fOnTop = ontop; };
 	void	SetSingleClick(bool singleclick) { fSingleClick = singleclick; };
 	void	SetShowIgnore(int32 ignore) { fShowIgnore = ignore; };
+	void	SetUseContains(int32 usecontains) { fUseContains = usecontains; };
 
 	BRect	GetMainWindowFrame() { return fMainWindowFrame; };
 	BRect	GetSetupWindowFrame() { return fSetupWindowFrame; };
@@ -50,6 +51,7 @@ public:
 	int32	GetSingleClick() { return fSingleClick; };
 	int32	GetOnTop() { return fOnTop; };
 	int32	GetShowIgnore() { return fShowIgnore; };
+	int32	GetUseContains() { return fUseContains; };
 
 	void			InitLists();
 	IgnoreListView* IgnoreList() { return fIgnoreList; };
@@ -69,6 +71,7 @@ private:
 	int32	fSingleClick;
 	int32	fOnTop;
 	int32	fShowIgnore;
+	int32	fUseContains;
 
 	BLocker	fLock;
 };

--- a/QLSettings.h
+++ b/QLSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017. All rights reserved.
+ * Copyright 2010-2018. All rights reserved.
  * Distributed under the terms of the MIT license.
  *
  * Author:
@@ -32,26 +32,26 @@ public:
 	void	SetDeskbar(int32 deskbar) { fDeskbar = deskbar; };
 	void	SetShowVersion(int32 version) { fShowVersion = version; };
 	void	SetShowPath(int32 path) { fShowPath = path; };
+	void	SetSearchStart(int32 searchstart) { fSearchStart = searchstart; };
 	void	SetDelay(int32 delay) { fDelay = delay; };
 	void	SetSaveSearch(int32 savesearch) { fSaveSearch = savesearch; };
 	void	SetSearchTerm(BString searchterm) { fSearchTerm = searchterm; };
 	void	SetOnTop(int32 ontop) { fOnTop = ontop; };
 	void	SetSingleClick(bool singleclick) { fSingleClick = singleclick; };
 	void	SetShowIgnore(int32 ignore) { fShowIgnore = ignore; };
-	void	SetSearchStart(int32 searchstart) { fSearchStart = searchstart; };
 
 	BRect	GetMainWindowFrame() { return fMainWindowFrame; };
 	BRect	GetSetupWindowFrame() { return fSetupWindowFrame; };
 	int32	GetDeskbar() { return fDeskbar; };
 	int32	GetShowVersion() { return fShowVersion; };
 	int32	GetShowPath() { return fShowPath; };
+	int32	GetSearchStart() { return fSearchStart; };
 	int32	GetDelay() { return fDelay; };
 	int32	GetSaveSearch() { return fSaveSearch; };
 	BString	GetSearchTerm() { return fSearchTerm; };
 	int32	GetSingleClick() { return fSingleClick; };
 	int32	GetOnTop() { return fOnTop; };
 	int32	GetShowIgnore() { return fShowIgnore; };
-	int32	GetSearchStart() { return fSearchStart; };
 
 	void			InitLists();
 	IgnoreListView* IgnoreList() { return fIgnoreList; };
@@ -65,13 +65,13 @@ private:
 	int32	fDeskbar;
 	int32	fShowVersion;
 	int32	fShowPath;
+	int32	fSearchStart;
 	int32	fDelay;
 	int32	fSaveSearch;
 	BString	fSearchTerm;
 	int32	fSingleClick;
 	int32	fOnTop;
 	int32	fShowIgnore;
-	int32	fSearchStart;
 
 	BLocker	fLock;
 };

--- a/QuickLaunch.cpp
+++ b/QuickLaunch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017. All rights reserved.
+ * Copyright 2010-2018. All rights reserved.
  * Distributed under the terms of the MIT license.
  *
  * Author:
@@ -176,6 +176,23 @@ QLApp::MessageReceived(BMessage* message)
 			}
 			break;
 		}
+		case SEARCHSTART_CHK:
+		{
+			int32 value;
+			message->FindInt32("be:value", &value);
+
+			if (fSettings.Lock()) {
+				fSettings.SetSearchStart(value);
+				fSettings.Unlock();
+			}
+
+			if (!fMainWindow->fListView->IsEmpty()) {
+				fMainWindow->LockLooper();
+				fMainWindow->fListView->Invalidate();
+				fMainWindow->UnlockLooper();
+			}
+			break;
+		}
 		case DELAY_CHK:
 		{
 			int32 value;
@@ -220,23 +237,6 @@ QLApp::MessageReceived(BMessage* message)
 			if (fSettings.Lock()) {
 				fSettings.SetOnTop(value);
 				fSettings.Unlock();
-			}
-			break;
-		}
-		case SEARCHSTART_CHK:
-		{
-			int32 value;
-			message->FindInt32("be:value", &value);
-
-			if (fSettings.Lock()) {
-				fSettings.SetSearchStart(value);
-				fSettings.Unlock();
-			}
-
-			if (!fMainWindow->fListView->IsEmpty()) {
-				fMainWindow->LockLooper();
-				fMainWindow->fListView->Invalidate();
-				fMainWindow->UnlockLooper();
 			}
 			break;
 		}

--- a/QuickLaunch.cpp
+++ b/QuickLaunch.cpp
@@ -188,7 +188,7 @@ QLApp::MessageReceived(BMessage* message)
 
 			if (!fMainWindow->fListView->IsEmpty()) {
 				fMainWindow->LockLooper();
-				fMainWindow->fListView->Invalidate();
+				fMainWindow->BuildList();
 				fMainWindow->UnlockLooper();
 			}
 			break;

--- a/QuickLaunch.cpp
+++ b/QuickLaunch.cpp
@@ -223,13 +223,13 @@ QLApp::MessageReceived(BMessage* message)
 			}
 			break;
 		}
-		case USECONTAINS_CHK:
+		case SEARCHSTART_CHK:
 		{
 			int32 value;
 			message->FindInt32("be:value", &value);
 
 			if (fSettings.Lock()) {
-				fSettings.SetUseContains(value);
+				fSettings.SetSearchStart(value);
 				fSettings.Unlock();
 			}
 

--- a/QuickLaunch.cpp
+++ b/QuickLaunch.cpp
@@ -223,6 +223,23 @@ QLApp::MessageReceived(BMessage* message)
 			}
 			break;
 		}
+		case USECONTAINS_CHK:
+		{
+			int32 value;
+			message->FindInt32("be:value", &value);
+
+			if (fSettings.Lock()) {
+				fSettings.SetUseContains(value);
+				fSettings.Unlock();
+			}
+
+			if (!fMainWindow->fListView->IsEmpty()) {
+				fMainWindow->LockLooper();
+				fMainWindow->fListView->Invalidate();
+				fMainWindow->UnlockLooper();
+			}
+			break;
+		}
 		case IGNORE_CHK:
 		{
 			if (fSettings.fIgnoreList->IsEmpty()) {

--- a/SetupWindow.cpp
+++ b/SetupWindow.cpp
@@ -69,11 +69,14 @@ SetupWindow::SetupWindow(BRect frame)
 		B_TRANSLATE("Window always on top"),
 		new BMessage(ONTOP_CHK), B_WILL_DRAW | B_NAVIGABLE);
 	fChkOnTop->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
+	fChkUseContains = new BCheckBox("UseContainsChk",
+		B_TRANSLATE("Search using Contains, instead of Begins With"),
+		new BMessage(USECONTAINS_CHK), B_WILL_DRAW | B_NAVIGABLE);
+	fChkUseContains->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
 	fChkIgnore = new BCheckBox("IgnoreChk",
 		B_TRANSLATE("Ignore these files & folders (and their subfolders):"),
 		new BMessage(IGNORE_CHK), B_WILL_DRAW | B_NAVIGABLE);
 	fChkIgnore->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
-
 	fIgnoreScroll = new BScrollView("IgnoreList", fIgnoreList,
 		B_WILL_DRAW | B_NAVIGABLE, false, true, B_FANCY_BORDER);
 	fIgnoreScroll->SetExplicitMinSize(BSize(B_SIZE_UNSET, 48));
@@ -92,10 +95,11 @@ SetupWindow::SetupWindow(BRect frame)
 	fChkPath->SetTarget(be_app);
 	fChkDelay->SetTarget(be_app);
 	fChkSaveSearch->SetTarget(be_app);
-	fChkOnTop->SetTarget(be_app);
 	fChkSingleClick->SetTarget(be_app);
+	fChkOnTop->SetTarget(be_app);
+	fChkUseContains->SetTarget(be_app);
 	fChkIgnore->SetTarget(be_app);
-
+	
 	// Build the layout
 
 	float spacing = be_control_look->DefaultItemSpacing();
@@ -115,6 +119,7 @@ SetupWindow::SetupWindow(BRect frame)
 			.Add(fChkSaveSearch)
 			.Add(fChkSingleClick)
 			.Add(fChkOnTop)
+			.Add(fChkUseContains)
 			.SetInsets(spacing, spacing, spacing, 0)
 		.End()
 		.AddGroup(B_VERTICAL, 0)
@@ -140,6 +145,7 @@ SetupWindow::SetupWindow(BRect frame)
 		fChkSingleClick->SetValue(settings.GetSingleClick());
 		fChkOnTop->SetValue(settings.GetOnTop());
 		fChkIgnore->SetValue(settings.GetShowIgnore());
+		fChkUseContains->SetValue(settings.GetUseContains());
 
 		settings.Unlock();
 	}

--- a/SetupWindow.cpp
+++ b/SetupWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017. All rights reserved.
+ * Copyright 2010-2018. All rights reserved.
  * Distributed under the terms of the MIT license.
  *
  * Author:
@@ -53,6 +53,10 @@ SetupWindow::SetupWindow(BRect frame)
 	fChkPath = new BCheckBox("PathChk", B_TRANSLATE("Show application path"),
 		new BMessage(PATH_CHK), B_WILL_DRAW | B_NAVIGABLE);
 	fChkPath->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
+	fChkSearchStart = new BCheckBox("SearchStartChk",
+		B_TRANSLATE("Search from start of application name"),
+		new BMessage(SEARCHSTART_CHK), B_WILL_DRAW | B_NAVIGABLE);
+	fChkSearchStart->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));	
 	fChkDelay = new BCheckBox("DelayChk",
 		B_TRANSLATE("Wait for a second letter before searching"),
 		new BMessage(DELAY_CHK), B_WILL_DRAW | B_NAVIGABLE);
@@ -61,10 +65,6 @@ SetupWindow::SetupWindow(BRect frame)
 		B_TRANSLATE("Remember last search term"),
 		new BMessage(SAVESEARCH_CHK), B_WILL_DRAW | B_NAVIGABLE);
 	fChkSaveSearch->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
-	fChkSearchStart = new BCheckBox("SearchStartChk",
-		B_TRANSLATE("Search from start of application name"),
-		new BMessage(SEARCHSTART_CHK), B_WILL_DRAW | B_NAVIGABLE);
-	fChkSearchStart->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));	
 	fChkSingleClick = new BCheckBox("SingleClickChk",
 		B_TRANSLATE("Launch applications with a single click"),
 		new BMessage(SINGLECLICK_CHK), B_WILL_DRAW | B_NAVIGABLE);
@@ -93,9 +93,9 @@ SetupWindow::SetupWindow(BRect frame)
 	fChkDeskbar->SetTarget(be_app);
 	fChkVersion->SetTarget(be_app);
 	fChkPath->SetTarget(be_app);
+	fChkSearchStart->SetTarget(be_app);
 	fChkDelay->SetTarget(be_app);
 	fChkSaveSearch->SetTarget(be_app);
-	fChkSearchStart->SetTarget(be_app);
 	fChkSingleClick->SetTarget(be_app);
 	fChkOnTop->SetTarget(be_app);
 	fChkIgnore->SetTarget(be_app);
@@ -115,9 +115,9 @@ SetupWindow::SetupWindow(BRect frame)
 			.SetInsets(spacing, spacing, spacing, 0)
 		.End()
 		.AddGroup(B_VERTICAL, 0)
+			.Add(fChkSearchStart)
 			.Add(fChkDelay)
 			.Add(fChkSaveSearch)
-			.Add(fChkSearchStart)
 			.SetInsets(spacing, spacing, spacing, 0)
 		.End()
 		.AddGroup(B_VERTICAL, 0)
@@ -143,9 +143,9 @@ SetupWindow::SetupWindow(BRect frame)
 		fChkDeskbar->SetValue(settings.GetDeskbar());
 		fChkVersion->SetValue(settings.GetShowVersion());
 		fChkPath->SetValue(settings.GetShowPath());
+		fChkSearchStart->SetValue(settings.GetSearchStart());
 		fChkDelay->SetValue(settings.GetDelay());
 		fChkSaveSearch->SetValue(settings.GetSaveSearch());
-		fChkSearchStart->SetValue(settings.GetSearchStart());
 		fChkSingleClick->SetValue(settings.GetSingleClick());
 		fChkOnTop->SetValue(settings.GetOnTop());
 		fChkIgnore->SetValue(settings.GetShowIgnore());

--- a/SetupWindow.cpp
+++ b/SetupWindow.cpp
@@ -61,6 +61,10 @@ SetupWindow::SetupWindow(BRect frame)
 		B_TRANSLATE("Remember last search term"),
 		new BMessage(SAVESEARCH_CHK), B_WILL_DRAW | B_NAVIGABLE);
 	fChkSaveSearch->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
+	fChkSearchStart = new BCheckBox("SearchStartChk",
+		B_TRANSLATE("Search from start of application name"),
+		new BMessage(SEARCHSTART_CHK), B_WILL_DRAW | B_NAVIGABLE);
+	fChkSearchStart->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));	
 	fChkSingleClick = new BCheckBox("SingleClickChk",
 		B_TRANSLATE("Launch applications with a single click"),
 		new BMessage(SINGLECLICK_CHK), B_WILL_DRAW | B_NAVIGABLE);
@@ -69,10 +73,6 @@ SetupWindow::SetupWindow(BRect frame)
 		B_TRANSLATE("Window always on top"),
 		new BMessage(ONTOP_CHK), B_WILL_DRAW | B_NAVIGABLE);
 	fChkOnTop->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
-	fChkUseContains = new BCheckBox("UseContainsChk",
-		B_TRANSLATE("Search using Contains, instead of Begins With"),
-		new BMessage(USECONTAINS_CHK), B_WILL_DRAW | B_NAVIGABLE);
-	fChkUseContains->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
 	fChkIgnore = new BCheckBox("IgnoreChk",
 		B_TRANSLATE("Ignore these files & folders (and their subfolders):"),
 		new BMessage(IGNORE_CHK), B_WILL_DRAW | B_NAVIGABLE);
@@ -95,11 +95,11 @@ SetupWindow::SetupWindow(BRect frame)
 	fChkPath->SetTarget(be_app);
 	fChkDelay->SetTarget(be_app);
 	fChkSaveSearch->SetTarget(be_app);
+	fChkSearchStart->SetTarget(be_app);
 	fChkSingleClick->SetTarget(be_app);
 	fChkOnTop->SetTarget(be_app);
-	fChkUseContains->SetTarget(be_app);
 	fChkIgnore->SetTarget(be_app);
-	
+
 	// Build the layout
 
 	float spacing = be_control_look->DefaultItemSpacing();
@@ -117,9 +117,12 @@ SetupWindow::SetupWindow(BRect frame)
 		.AddGroup(B_VERTICAL, 0)
 			.Add(fChkDelay)
 			.Add(fChkSaveSearch)
+			.Add(fChkSearchStart)
+			.SetInsets(spacing, spacing, spacing, 0)
+		.End()
+		.AddGroup(B_VERTICAL, 0)
 			.Add(fChkSingleClick)
 			.Add(fChkOnTop)
-			.Add(fChkUseContains)
 			.SetInsets(spacing, spacing, spacing, 0)
 		.End()
 		.AddGroup(B_VERTICAL, 0)
@@ -142,10 +145,10 @@ SetupWindow::SetupWindow(BRect frame)
 		fChkPath->SetValue(settings.GetShowPath());
 		fChkDelay->SetValue(settings.GetDelay());
 		fChkSaveSearch->SetValue(settings.GetSaveSearch());
+		fChkSearchStart->SetValue(settings.GetSearchStart());
 		fChkSingleClick->SetValue(settings.GetSingleClick());
 		fChkOnTop->SetValue(settings.GetOnTop());
 		fChkIgnore->SetValue(settings.GetShowIgnore());
-		fChkUseContains->SetValue(settings.GetUseContains());
 
 		settings.Unlock();
 	}

--- a/SetupWindow.h
+++ b/SetupWindow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2017. All rights reserved.
+ * Copyright 2010-2018. All rights reserved.
  * Distributed under the terms of the MIT license.
  *
  * Author:
@@ -37,6 +37,7 @@
 #define VERSION_CHK		'chve'
 #define PATH_CHK		'chpa'
 #define DELAY_CHK		'chde'
+#define SEARCHSTART_CHK	'chst'
 #define SAVESEARCH_CHK	'chss'
 #define SINGLECLICK_CHK	'ch1c'
 #define ONTOP_CHK		'chot'
@@ -44,8 +45,7 @@
 #define ADD_BUT			'addb'
 #define REM_BUT			'remb'
 #define FILEPANEL		'file'
-#define POPCLOSE		'clpo'
-#define SEARCHSTART_CHK	'chst' 
+#define POPCLOSE		'clpo' 
 
 class SetupWindow : public BWindow {
 public:
@@ -58,9 +58,9 @@ public:
 	BCheckBox*		fChkDeskbar;
 	BCheckBox*		fChkVersion;
 	BCheckBox*		fChkPath;
+	BCheckBox*		fChkSearchStart;
 	BCheckBox*		fChkDelay;
 	BCheckBox*		fChkSaveSearch;
-	BCheckBox*		fChkSearchStart;
 	BCheckBox*		fChkSingleClick;
 	BCheckBox*		fChkOnTop;
 	BCheckBox*		fChkIgnore;

--- a/SetupWindow.h
+++ b/SetupWindow.h
@@ -45,7 +45,7 @@
 #define REM_BUT			'remb'
 #define FILEPANEL		'file'
 #define POPCLOSE		'clpo'
-#define USECONTAINS_CHK	'chuc' 
+#define SEARCHSTART_CHK	'chst' 
 
 class SetupWindow : public BWindow {
 public:
@@ -60,10 +60,10 @@ public:
 	BCheckBox*		fChkPath;
 	BCheckBox*		fChkDelay;
 	BCheckBox*		fChkSaveSearch;
+	BCheckBox*		fChkSearchStart;
 	BCheckBox*		fChkSingleClick;
 	BCheckBox*		fChkOnTop;
 	BCheckBox*		fChkIgnore;
-	BCheckBox*		fChkUseContains;
 	BButton*		fButRem;
 
 private:

--- a/SetupWindow.h
+++ b/SetupWindow.h
@@ -45,7 +45,7 @@
 #define REM_BUT			'remb'
 #define FILEPANEL		'file'
 #define POPCLOSE		'clpo'
-
+#define USECONTAINS_CHK	'chuc' 
 
 class SetupWindow : public BWindow {
 public:
@@ -63,6 +63,7 @@ public:
 	BCheckBox*		fChkSingleClick;
 	BCheckBox*		fChkOnTop;
 	BCheckBox*		fChkIgnore;
+	BCheckBox*		fChkUseContains;
 	BButton*		fButRem;
 
 private:


### PR DESCRIPTION
This adds an option that will search for applications using B_CONTAINS instead of B_BEGINS_WITH. 

I find this often results in getting to the desired application with fewer keystrokes. For example, if I want to launch Haiku Depot I will have to type "HaikuD" when searching using the current B_BEGINS_WITH, but I'd only have to type "Dep" if using B_CONTAINS.