### PR TITLE
Don't resize the window for small changes

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -412,8 +412,9 @@ MainWindow::ResizeWindow()
 	count = (count < kMAX_DISPLAYED_ITEMS) ? count : kMAX_DISPLAYED_ITEMS;
 	BRect itemRect = fListView->ItemFrame(0);
 	float itemHeight = itemRect.Height();
-	float windowRest = Frame().Height() - fListView->Frame().Height();
-	ResizeTo(Bounds().Width(), count * itemHeight + windowRest + count - 2);
+	float heightDelta = (count * (itemHeight + 1) - 1) - fListView->Frame().Height();
+	if (fabs(heightDelta) > 2)
+		ResizeTo(Bounds().Width(), Frame().Height() + heightDelta);
 }
 
 


### PR DESCRIPTION
Workarounds #36. We stil get different heights for the same list, but now the scroll bar is only enabled when needed and height doesn't jump while keeping the same results.

Still, I don't know the root cause. The bold ignorant in me smells an issue in BGroupLayout or nearby.