### PR TITLE
Fix overfiltering

### DIFF
--- a/src/IgnoreListItem.cpp
+++ b/src/IgnoreListItem.cpp
@@ -82,3 +82,24 @@ IgnoreListItem::DrawItem(BView* view, BRect rect, bool complete)
 	view->TruncateString(&string, B_TRUNCATE_MIDDLE, width - spacing);
 	view->DrawString(string.String());
 }
+
+
+#pragma mark-- Public Methods --
+
+
+bool
+IgnoreListItem::Ignores(const BString& path) const
+{
+	BString sPath = path;
+
+	if (fIsDirectory) {
+		BPath container = sPath.String();
+		while (sPath.Length() > GetItem().Length()) {
+			if (container.GetParent(&container) != B_OK)
+				break;
+			sPath = container.Path();
+		}
+	}
+
+	return sPath.Compare(GetItem()) == 0;
+}

--- a/src/IgnoreListItem.h
+++ b/src/IgnoreListItem.h
@@ -30,6 +30,7 @@ public:
 	virtual void	DrawItem(BView*, BRect, bool);
 
 	const BString&	GetItem() const { return fItemString; };
+	bool			Ignores(const BString& path) const;
 
 private:
 	BPath*			fPath;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -518,8 +518,7 @@ MainWindow::_BuildAppList()
 						IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(
 							settings.fIgnoreList->ItemAt(i));
 
-						if (newItem.Compare(sItem->GetItem(),
-							std::min(newItem.Length(), sItem->GetItem().Length())) == 0)
+						if (sItem->Ignores(newItem))
 							ignore = true;
 					}
 				}


### PR DESCRIPTION
We don't want to filter out `ba` and `barbeque` when we just have `bar` in the ignore list.