### PR TITLE
Move the app list builder to a BLooper

### DIFF
--- a/src/AppList.cpp
+++ b/src/AppList.cpp
@@ -13,6 +13,7 @@
 #include "QuickLaunch.h"
 
 #include <LocaleRoster.h>
+#include <NodeMonitor.h>
 #include <Path.h>
 #include <Query.h>
 #include <Volume.h>
@@ -29,6 +30,13 @@ AppList::AppList()
 }
 
 
+AppList::~AppList()
+{
+	if (fInit)
+		stop_watching(this);
+}
+
+
 void
 AppList::MessageReceived(BMessage* message)
 {
@@ -36,6 +44,28 @@ AppList::MessageReceived(BMessage* message)
 		case BUILDAPPLIST:
 		{
 			_BuildAppList();
+			break;
+		}
+		case B_NODE_MONITOR:
+		{
+			int32 opcode = message->GetInt32("opcode", -1);
+
+			if (opcode == B_DEVICE_MOUNTED) {
+				int32 device;
+				if (message->FindInt32("new device", 0, &device) != B_OK) {
+					_BuildAppList();
+					break;
+				}
+
+				bool localized = BLocaleRoster::Default()->IsFilesystemTranslationPreferred();
+				BVolume volume(device);
+				if (_AppendVolumeItems(volume, localized) > 0)
+					SendNotices(BUILDAPPLIST);
+
+			} else if (opcode == B_DEVICE_UNMOUNTED) {
+				_BuildAppList();
+			}
+
 			break;
 		}
 		default:
@@ -60,108 +90,120 @@ AppList::Items()
 }
 
 
-void
-AppList::_BuildAppList()
+int
+AppList::_AppendVolumeItems(const BVolume& volume, bool localized)
 {
-	fAppList.MakeEmpty();
+	if (volume.InitCheck() != B_OK || !volume.KnowsQuery())
+		return 0;
+
 	QLSettings& settings = my_app->Settings();
+	int32 ignoreCount;
+	if (settings.GetTempApplyIgnore())
+		ignoreCount = settings.fIgnoreList->CountItems();
+	else
+		ignoreCount = 0;
 
-	bool localized = BLocaleRoster::Default()->IsFilesystemTranslationPreferred();
-	bool activeIgnore = settings.GetTempApplyIgnore();
-	int32 ignoreCount = settings.fIgnoreList->CountItems();
+	// Check if the whole volume is on ignore list
+	if (ignoreCount > 0) {
+		BDirectory root;
+		volume.GetRootDirectory(&root);
+		BPath mountPoint(&root, NULL);
 
-	BVolumeRoster volumeRoster;
-	BVolume volume;
-	BQuery query;
-
-	while (volumeRoster.GetNextVolume(&volume) == B_OK) {
-		if (volume.KnowsQuery()) {
-			// Check if the whole volume is on ignore list
-			if (activeIgnore && ignoreCount != 0) {
-				bool ignore = false;
-				BDirectory root;
-				volume.GetRootDirectory(&root);
-				BPath mountPoint(&root, NULL);
-
-				BString newItem(mountPoint.Path());
-				for (int i = 0; i < ignoreCount; i++) {
-					IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(
-						settings.fIgnoreList->ItemAt(i));
-
-					if (newItem.Compare(sItem->GetItem()) == 0) {
-						ignore = true;
-						break;
-					}
-				}
-				if (ignore)
-					continue;
-			}
-
-			char trashPath[B_PATH_NAME_LENGTH];
-			size_t trashPathLength;
-			if (find_directory(B_TRASH_DIRECTORY, volume.Device(), false, trashPath, sizeof(trashPath)) == B_OK)
-				trashPathLength = strlen(trashPath);
-			else
-				trashPathLength = 0;
-
-			// Set up the volume and predicate for the query.
-			query.SetVolume(&volume);
-			query.PushAttr("BEOS:TYPE");
-			query.PushString("application/x-vnd.be-elfexecutable", true);
-			query.PushOp(B_EQ);
-
-			query.PushAttr("BEOS:APP_SIG");
-			query.PushString("application/x");
-			query.PushOp(B_BEGINS_WITH);
-			query.PushOp(B_AND);
-
-			status_t status = query.Fetch();
-
-			if (status != B_OK)
-				printf("2. what happened? %s\n", strerror(status));
-
-			BEntry entry;
-			BPath path;
-			while (query.GetNextEntry(&entry) == B_OK) {
-				if (!entry.IsFile())
-					continue;
-
-				if (entry.GetPath(&path) < B_OK) {
-					fprintf(stderr, "could not get path for entry\n");
-					continue;
-				}
-
-				BPath parent;
-				entry.GetPath(&path);
-				path.GetParent(&parent);
-
-				// ignore Trash
-				if (trashPathLength > 0 && strncmp(parent.Path(), trashPath, trashPathLength) == 0) {
-					char nextChar = parent.Path()[trashPathLength];
-					if (nextChar == '\0' || nextChar == '/')
-						continue;
-				}
-
-				bool ignore = false;
-				if (activeIgnore && ignoreCount != 0) {
-					BString newItem(path.Path());
-					for (int i = 0; i < ignoreCount; i++) {
-						IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(
-							settings.fIgnoreList->ItemAt(i));
-
-						if (sItem->Ignores(newItem)) {
-							ignore = true;
-							break;
-						}
-					}
-				}
-				if (!ignore && entry.InitCheck() == B_OK)
-					fAppList.AddItem(new AppListItem(entry, localized));
-			}
-			query.Clear();
+		BString newItem(mountPoint.Path());
+		for (int i = 0; i < ignoreCount; i++) {
+			IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(settings.fIgnoreList->ItemAt(i));
+			if (sItem->Ignores(newItem))
+				return 0;
 		}
 	}
 
-	fInit = true;
+	int appended = 0;
+	BQuery query;
+
+	char trashPath[B_PATH_NAME_LENGTH];
+	size_t trashPathLength;
+	if (find_directory(B_TRASH_DIRECTORY, volume.Device(), false, trashPath, sizeof(trashPath)) == B_OK)
+		trashPathLength = strlen(trashPath);
+	else
+		trashPathLength = 0;
+
+	// Set up the volume and predicate for the query.
+	query.SetVolume(&volume);
+	query.PushAttr("BEOS:TYPE");
+	query.PushString("application/x-vnd.be-elfexecutable", true);
+	query.PushOp(B_EQ);
+
+	query.PushAttr("BEOS:APP_SIG");
+	query.PushString("application/x");
+	query.PushOp(B_BEGINS_WITH);
+	query.PushOp(B_AND);
+
+	status_t status = query.Fetch();
+
+	if (status != B_OK)
+		printf("2. what happened? %s\n", strerror(status));
+
+	BEntry entry;
+	BPath path;
+	while (query.GetNextEntry(&entry) == B_OK) {
+		if (!entry.IsFile())
+			continue;
+
+		if (entry.GetPath(&path) < B_OK) {
+			fprintf(stderr, "could not get path for entry\n");
+			continue;
+		}
+
+		BPath parent;
+		entry.GetPath(&path);
+		path.GetParent(&parent);
+
+		// ignore Trash
+		if (trashPathLength > 0 && strncmp(parent.Path(), trashPath, trashPathLength) == 0) {
+			char nextChar = parent.Path()[trashPathLength];
+			if (nextChar == '\0' || nextChar == '/')
+				continue;
+		}
+
+		bool ignore = false;
+		if (ignoreCount > 0) {
+			BString newItem(path.Path());
+			for (int i = 0; i < ignoreCount; i++) {
+				IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(
+					settings.fIgnoreList->ItemAt(i));
+
+				if (sItem->Ignores(newItem)) {
+					ignore = true;
+					break;
+				}
+			}
+		}
+		if (!ignore && entry.InitCheck() == B_OK) {
+			fAppList.AddItem(new AppListItem(entry, localized));
+			appended++;
+		}
+	}
+	query.Clear();
+	return appended;
+}
+
+
+void
+AppList::_BuildAppList()
+{
+	if (!fInit) {
+		fInit = true;
+		watch_node(NULL, B_WATCH_MOUNT, this);
+	}
+
+	fAppList.MakeEmpty();
+
+	bool localized = BLocaleRoster::Default()->IsFilesystemTranslationPreferred();
+
+	BVolumeRoster volumeRoster;
+	BVolume volume;
+	while (volumeRoster.GetNextVolume(&volume) == B_OK)
+		_AppendVolumeItems(volume, localized);
+
 	SendNotices(BUILDAPPLIST);
 }

--- a/src/AppList.cpp
+++ b/src/AppList.cpp
@@ -97,6 +97,13 @@ AppList::_BuildAppList()
 					continue;
 			}
 
+			char trashPath[B_PATH_NAME_LENGTH];
+			size_t trashPathLength;
+			if (find_directory(B_TRASH_DIRECTORY, volume.Device(), false, trashPath, sizeof(trashPath)) == B_OK)
+				trashPathLength = strlen(trashPath);
+			else
+				trashPathLength = 0;
+
 			// Set up the volume and predicate for the query.
 			query.SetVolume(&volume);
 			query.PushAttr("BEOS:TYPE");
@@ -128,10 +135,10 @@ AppList::_BuildAppList()
 				entry.GetPath(&path);
 				path.GetParent(&parent);
 
-				// ignore Trash on all volumes
-				BPath trashDir;
-				if (find_directory(B_TRASH_DIRECTORY, &trashDir, false, &volume) == B_OK) {
-					if (strstr(parent.Path(), trashDir.Path()))
+				// ignore Trash
+				if (trashPathLength > 0 && strncmp(parent.Path(), trashPath, trashPathLength) == 0) {
+					char nextChar = parent.Path()[trashPathLength];
+					if (nextChar == '\0' || nextChar == '/')
 						continue;
 				}
 

--- a/src/AppList.cpp
+++ b/src/AppList.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2010-2024. All rights reserved.
+ * Distributed under the terms of the MIT license.
+ *
+ * Authors:
+ *	Humdinger, humdinger@mailbox.org
+ */
+
+#include "AppList.h"
+
+#include "IgnoreListItem.h"
+#include "QLSettings.h"
+#include "QuickLaunch.h"
+
+#include <LocaleRoster.h>
+#include <Path.h>
+#include <Query.h>
+#include <Volume.h>
+#include <VolumeRoster.h>
+
+
+AppList::AppList()
+	:
+	BLooper("app list builder"),
+	fInit(false),
+	fAppList(20, true)
+{
+	Run();
+}
+
+
+void
+AppList::MessageReceived(BMessage* message)
+{
+	switch (message->what) {
+		case BUILDAPPLIST:
+		{
+			_BuildAppList();
+			break;
+		}
+		default:
+		{
+			BLooper::MessageReceived(message);
+			break;
+		}
+	}
+}
+
+
+const AppListItems*
+AppList::Items()
+{
+	if (IsLocked() && fInit)
+		return &fAppList;
+
+	if (!fInit)
+		PostMessage(BUILDAPPLIST);
+
+	return NULL;
+}
+
+
+void
+AppList::_BuildAppList()
+{
+	fAppList.MakeEmpty();
+	QLSettings& settings = my_app->Settings();
+
+	bool localized = BLocaleRoster::Default()->IsFilesystemTranslationPreferred();
+	bool activeIgnore = settings.GetTempApplyIgnore();
+	int32 ignoreCount = settings.fIgnoreList->CountItems();
+
+	BVolumeRoster volumeRoster;
+	BVolume volume;
+	BQuery query;
+
+	while (volumeRoster.GetNextVolume(&volume) == B_OK) {
+		if (volume.KnowsQuery()) {
+			// Check if the whole volume is on ignore list
+			if (activeIgnore && ignoreCount != 0) {
+				bool ignore = false;
+				BDirectory root;
+				volume.GetRootDirectory(&root);
+				BPath mountPoint(&root, NULL);
+
+				BString newItem(mountPoint.Path());
+				for (int i = 0; i < ignoreCount; i++) {
+					IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(
+						settings.fIgnoreList->ItemAt(i));
+
+					if (newItem.Compare(sItem->GetItem()) == 0) {
+						ignore = true;
+						break;
+					}
+				}
+				if (ignore)
+					continue;
+			}
+
+			// Set up the volume and predicate for the query.
+			query.SetVolume(&volume);
+			query.PushAttr("BEOS:TYPE");
+			query.PushString("application/x-vnd.be-elfexecutable", true);
+			query.PushOp(B_EQ);
+
+			query.PushAttr("BEOS:APP_SIG");
+			query.PushString("application/x");
+			query.PushOp(B_BEGINS_WITH);
+			query.PushOp(B_AND);
+
+			status_t status = query.Fetch();
+
+			if (status != B_OK)
+				printf("2. what happened? %s\n", strerror(status));
+
+			BEntry entry;
+			BPath path;
+			while (query.GetNextEntry(&entry) == B_OK) {
+				if (!entry.IsFile())
+					continue;
+
+				if (entry.GetPath(&path) < B_OK) {
+					fprintf(stderr, "could not get path for entry\n");
+					continue;
+				}
+
+				BPath parent;
+				entry.GetPath(&path);
+				path.GetParent(&parent);
+
+				// ignore Trash on all volumes
+				BPath trashDir;
+				if (find_directory(B_TRASH_DIRECTORY, &trashDir, false, &volume) == B_OK) {
+					if (strstr(parent.Path(), trashDir.Path()))
+						continue;
+				}
+
+				bool ignore = false;
+				if (activeIgnore && ignoreCount != 0) {
+					BString newItem(path.Path());
+					for (int i = 0; i < ignoreCount; i++) {
+						IgnoreListItem* sItem = dynamic_cast<IgnoreListItem*>(
+							settings.fIgnoreList->ItemAt(i));
+
+						if (sItem->Ignores(newItem)) {
+							ignore = true;
+							break;
+						}
+					}
+				}
+				if (!ignore && entry.InitCheck() == B_OK)
+					fAppList.AddItem(new AppListItem(entry, localized));
+			}
+			query.Clear();
+		}
+	}
+
+	fInit = true;
+	SendNotices(BUILDAPPLIST);
+}

--- a/src/AppList.h
+++ b/src/AppList.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024. All rights reserved.
+ * Distributed under the terms of the MIT license.
+ *
+ */
+#ifndef APPLIST_H
+#define APPLIST_H
+
+
+#include "AppListItem.h"
+
+#include <Looper.h>
+#include <ObjectList.h>
+
+
+typedef BObjectList<AppListItem> AppListItems;
+
+
+class AppList : public BLooper {
+public:
+							AppList();
+
+	void					MessageReceived(BMessage* message);
+
+	const AppListItems*		Items();
+
+private:
+	void					_BuildAppList();
+
+private:
+	bool					fInit;
+	AppListItems			fAppList;
+
+};
+
+
+#endif // APPLIST_H

--- a/src/AppList.h
+++ b/src/AppList.h
@@ -11,6 +11,7 @@
 
 #include <Looper.h>
 #include <ObjectList.h>
+#include <Volume.h>
 
 
 typedef BObjectList<AppListItem> AppListItems;
@@ -19,12 +20,14 @@ typedef BObjectList<AppListItem> AppListItems;
 class AppList : public BLooper {
 public:
 							AppList();
+	virtual					~AppList();
 
 	void					MessageReceived(BMessage* message);
 
 	const AppListItems*		Items();
 
 private:
+	int						_AppendVolumeItems(const BVolume& volume, bool localized);
 	void					_BuildAppList();
 
 private:

--- a/src/MainListItem.h
+++ b/src/MainListItem.h
@@ -35,6 +35,7 @@ public:
 	BBitmap*		Bitmap() { return fIcon; };
 	char*			GetName() { return fName; };
 	entry_ref*		Ref() { return &fRef; };
+	const BPath&	Path() { return fPath; };
 	bool			IsFavorite() { return fIsFavorite; };
 	void			SetFavorite(bool state);
 

--- a/src/MainListView.cpp
+++ b/src/MainListView.cpp
@@ -223,7 +223,7 @@ MainListView::MessageReceived(BMessage* message)
 				if (window->IsFavoritesOnly()) { // remove from result list
 					delete RemoveItem(selection);
 					Select((selection - 1 < 0) ? 0 : selection - 1);
-					window->ResizeWindow();
+					window->ResultsCountChanged();
 				}
 			}
 

--- a/src/MainListView.cpp
+++ b/src/MainListView.cpp
@@ -67,7 +67,7 @@ void
 MainListView::Draw(BRect rect)
 {
 	MainWindow* window = dynamic_cast<MainWindow*>(Window());
-	int letters = window->GetStringLength();
+	bool emptySearch = window->IsFavoritesOnly();
 	float width, height;
 	BFont font;
 
@@ -80,7 +80,7 @@ MainListView::Draw(BRect rect)
 		BString string;
 
 		if (settings.Lock()) {
-			if (letters == 0)
+			if (emptySearch)
 				string = B_TRANSLATE("Enter the app's name.");
 			else
 				string = B_TRANSLATE("Found no matches.");
@@ -103,7 +103,7 @@ MainListView::Draw(BRect rect)
 	BListView::Draw(rect);
 
 	// Only for Favorites == empty search field
-	if (fDropRect.IsValid() && letters == 0) {
+	if (fDropRect.IsValid() && emptySearch) {
 		SetHighColor(255, 0, 0, 255);
 		StrokeRect(fDropRect);
 	}
@@ -220,9 +220,7 @@ MainListView::MessageReceived(BMessage* message)
 
 			if (wasFavorite) {
 				MainWindow* window = dynamic_cast<MainWindow*>(Window());
-				int letters = window->GetStringLength();
-
-				if (letters == 0) { // remove from result list
+				if (window->IsFavoritesOnly()) { // remove from result list
 					delete RemoveItem(selection);
 					Select((selection - 1 < 0) ? 0 : selection - 1);
 					window->ResizeWindow();
@@ -272,7 +270,7 @@ MainListView::MessageReceived(BMessage* message)
 				break;
 
 			// see if we're dragging a Favorite in a result list
-			if (my_app->fMainWindow->GetStringLength() > 0)
+			if (!my_app->fMainWindow->IsFavoritesOnly())
 				break;
 
 			int32 origIndex;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -614,7 +614,9 @@ void
 MainWindow::_RebuildResults()
 {
 	int32 selection = fListView->CurrentSelection();
-	float position = _GetScrollPosition();
+	entry_ref ref;
+	if (selection >= 0)
+		ref = *dynamic_cast<MainListItem*>(fListView->ItemAt(selection))->Ref();
 
 	fListView->MakeEmpty();
 
@@ -624,13 +626,19 @@ MainWindow::_RebuildResults()
 		_FilterAppList();
 
 	if (selection >= 0) {
-		fListView->Select((selection < fListView->CountItems())
-				? selection : fListView->CountItems() - 1);
+		int32 count = fListView->CountItems();
+		for (int32 i = 0; i < count; i++) {
+			if (ref == *dynamic_cast<MainListItem*>(fListView->ItemAt(i))->Ref()) {
+				selection = i;
+				break;
+			}
+		}
+		fListView->Select((selection < count) ? selection : count - 1);
 	} else if (!fListView->IsEmpty())
 		fListView->Select(0);
 
 	ResultsCountChanged();
-	_SetScrollPosition(position);
+	fListView->ScrollToSelection();
 }
 
 
@@ -686,25 +694,6 @@ MainWindow::_FilterAppList()
 			fListView->SortItems(&compare_items);
 	}
 	settings.Unlock();
-}
-
-
-float
-MainWindow::_GetScrollPosition()
-{
-	float position;
-	BScrollBar* scrollBar = fScrollView->ScrollBar(B_VERTICAL);
-	position = scrollBar->Value();
-	return (position);
-}
-
-
-void
-MainWindow::_SetScrollPosition(float position)
-{
-	BScrollBar* scrollBar = fScrollView->ScrollBar(B_VERTICAL);
-	scrollBar->SetValue(position);
-	return;
 }
 
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -423,7 +423,7 @@ MainWindow::MessageReceived(BMessage* message)
 			settings.SetTempSearchStart(value);
 			fTempSearchStart->SetMarked(value);
 
-			if (!fListView->IsEmpty())
+			if (!(fListView->IsEmpty() && value))
 				_FilterKeepPositionSelection();
 
 			break;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -153,7 +153,7 @@ MainWindow::MainWindow()
 	fListView->SetInvocationMessage(new BMessage(RETURN_KEY));
 	fListView->SetViewColor(B_TRANSPARENT_COLOR);
 
-	if (searchstring == "")
+	if (IsFavoritesOnly())
 		_ShowFavorites();
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -151,14 +151,15 @@ MainWindow::MainWindow()
 			.SetInsets(B_USE_HALF_ITEM_SPACING)
 			.End();
 
+	Layout(false);
+
 	fSearchBox->MakeFocus(true);
 
 	AddCommonFilter(new QLFilter);
 	fListView->SetInvocationMessage(new BMessage(RETURN_KEY));
 	fListView->SetViewColor(B_TRANSPARENT_COLOR);
 
-	if (IsFavoritesOnly())
-		_RebuildResults();
+	_RebuildResults();
 }
 
 
@@ -652,8 +653,12 @@ MainWindow::_FilterAppList()
 	if (fBusy)
 		return;
 
-	if (fAppList.IsEmpty())
+	if (fAppList.IsEmpty()) {
 		BuildAppList();
+
+		// Give up. We'll be called again when the app list is built.
+		return;
+	}
 
 	QLSettings& settings = my_app->Settings();
 	BString searchtext = GetSearchString();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -38,7 +38,11 @@ compare_items(const void* a, const void* b)
 	MainListItem* stringA = *(MainListItem**)a;
 	MainListItem* stringB = *(MainListItem**)b;
 
-	return strcasecmp(stringA->GetName(), stringB->GetName());
+	int cmp = strcasecmp(stringA->GetName(), stringB->GetName());
+	if (cmp != 0)
+		return cmp;
+
+	return strcasecmp(stringA->Path().Path(), stringB->Path().Path());
 }
 
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -9,7 +9,6 @@
 #ifndef QL_WINDOW_H
 #define QL_WINDOW_H
 
-#include "AppListItem.h"
 #include "MainListItem.h"
 #include "MainListView.h"
 
@@ -22,15 +21,10 @@
 #include <GroupLayoutBuilder.h>
 #include <ListView.h>
 #include <Message.h>
-#include <ObjectList.h>
-#include <Path.h>
-#include <Query.h>
 #include <Roster.h>
 #include <Screen.h>
 #include <ScrollView.h>
 #include <TextControl.h>
-#include <Volume.h>
-#include <VolumeRoster.h>
 #include <Window.h>
 
 #include <stdlib.h>
@@ -46,6 +40,9 @@
 #define kMAX_DISPLAYED_ITEMS	10
 
 
+class AppList;
+
+
 class MainWindow : public BWindow {
 public:
 					MainWindow();
@@ -55,16 +52,11 @@ public:
 	void			MessageReceived(BMessage* message);
 	bool			QuitRequested();
 
-	void			BuildAppList();
-
 	bool			IsFavoritesOnly() { return fSearchBox->TextView()->TextLength() == 0; };
 	const char*		GetSearchString() { return fSearchBox->TextView()->Text(); };
 	void			ResultsCountChanged();
 
 private:
-	static status_t _AppListThread(void* self);
-	void			_BuildAppList();
-
 	void			_RebuildResults();
 	void			_FilterAppList();
 	void			_ShowFavorites();
@@ -72,10 +64,7 @@ private:
 	void			_LaunchApp(MainListItem* item);
 	void			_AddDroppedAsFav(BMessage* message);
 
-	thread_id		fThreadId;
-	bool			fBusy;
-
-	BObjectList<AppListItem> fAppList;
+	AppList*		fAppList;
 	int32			fIconHeight;
 
 	BMenu*			fSelectionMenu;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -57,7 +57,7 @@ public:
 
 	void			BuildAppList();
 
-	int				GetStringLength() { return fSearchBox->TextView()->TextLength(); };
+	bool			IsFavoritesOnly() { return fSearchBox->TextView()->TextLength() == 0; };
 	const char*		GetSearchString() { return fSearchBox->TextView()->Text(); };
 	void			ResizeWindow();
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -59,22 +59,21 @@ public:
 
 	bool			IsFavoritesOnly() { return fSearchBox->TextView()->TextLength() == 0; };
 	const char*		GetSearchString() { return fSearchBox->TextView()->Text(); };
-	void			ResizeWindow();
-
-	MainListView*	fListView;
+	void			ResultsCountChanged();
 
 private:
 	static status_t _AppListThread(void* self);
 	void			_BuildAppList();
+
+	void			_RebuildResults();
 	void			_FilterAppList();
+	void			_ShowFavorites();
 
 	float			_GetScrollPosition();
 	void			_SetScrollPosition(float position);
-	void			_FilterKeepPositionSelection();
 
 	void			_LaunchApp(MainListItem* item);
 	void			_AddDroppedAsFav(BMessage* message);
-	void			_ShowFavorites();
 
 	thread_id		fThreadId;
 	bool			fBusy;
@@ -93,6 +92,7 @@ private:
 
 	BTextControl*	fSearchBox;
 	BScrollView*	fScrollView;
+	MainListView*	fListView;
 
 	BWindow*		fSetupWindow;
 };

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -69,9 +69,6 @@ private:
 	void			_FilterAppList();
 	void			_ShowFavorites();
 
-	float			_GetScrollPosition();
-	void			_SetScrollPosition(float position);
-
 	void			_LaunchApp(MainListItem* item);
 	void			_AddDroppedAsFav(BMessage* message);
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,6 +21,7 @@ APP_MIME_SIG = application/x-vnd.humdinger-quicklaunch
 #	so that Pe and Eddie can fill them in for you.
 #%{
 SRCS = \
+	 AppList.cpp \
 	 AppListItem.cpp \
 	 DeskbarReplicant.cpp  \
 	 MainListItem.cpp  \

--- a/src/QuickLaunch.cpp
+++ b/src/QuickLaunch.cpp
@@ -137,11 +137,8 @@ QLApp::ReadyToRun()
 	BRect frame = fSettings.GetMainWindowFrame();
 
 	fMainWindow->MoveTo(frame.LeftTop());
-	fMainWindow->ResizeTo(frame.right - frame.left, 0);
+	fMainWindow->ResizeBy(frame.Width() - fMainWindow->Frame().Width(), 0);
 	fMainWindow->Show();
-
-	// Initial filtering. Shows favorites and resizes window correctly
-	fMainWindow->PostMessage(NEW_FILTER);
 
 	watch_node(NULL, B_WATCH_MOUNT, this);
 }

--- a/src/QuickLaunch.cpp
+++ b/src/QuickLaunch.cpp
@@ -17,7 +17,6 @@
 #include <Catalog.h>
 #include <Deskbar.h>
 #include <PathFinder.h>
-#include <storage/NodeMonitor.h>
 
 const char* kApplicationSignature = "application/x-vnd.humdinger-quicklaunch";
 const char* kApplicationName = "QuickLaunch";
@@ -48,8 +47,6 @@ QLApp::QLApp()
 
 QLApp::~QLApp()
 {
-	stop_watching(this);
-
 	if (fMainWindow != NULL) {
 		BMessenger messengerMain(fMainWindow);
 		if (messengerMain.IsValid() && messengerMain.LockTarget())
@@ -107,14 +104,6 @@ QLApp::MessageReceived(BMessage* message)
 				_RemoveFromDeskbar();
 			break;
 		}
-		case B_NODE_MONITOR:
-		{
-			int32 opcode = message->GetInt32("opcode", -1);
-
-			if ((opcode == B_DEVICE_MOUNTED) || (opcode == B_DEVICE_UNMOUNTED))
-				fMainWindow->PostMessage(new BMessage(BUILDAPPLIST));
-			break;
-		}
 		default:
 		{
 			BApplication::MessageReceived(message);
@@ -139,8 +128,6 @@ QLApp::ReadyToRun()
 	fMainWindow->MoveTo(frame.LeftTop());
 	fMainWindow->ResizeBy(frame.Width() - fMainWindow->Frame().Width(), 0);
 	fMainWindow->Show();
-
-	watch_node(NULL, B_WATCH_MOUNT, this);
 }
 
 


### PR DESCRIPTION
Simplifies queueing and makes locking obvious. Should also make future changes easier.

Notice there's a bit more than just that here. In particular, these are user-visible and may be unwanted due to their effect on current muscle memory:
- When items have the same name, they are ordered by path, you won't get "random" order.
- When the results change, the same item is selected if found. Previously it was the same position in the list in some cases or back to the first item in others.